### PR TITLE
Show a message when OpenAI token is wrong or when the credits are exhausted

### DIFF
--- a/content.js
+++ b/content.js
@@ -421,6 +421,12 @@ async function summarizeResults_own_key(results, searchQuery) {
     });
 
     //console.log(response);
+    if (!response.ok) {
+        updateSummary(
+          'Either your credits are exhausted or you have entered the wrong OpenAPI token'
+        );
+        return;
+      }
 
     const reader = response.body.getReader();
     const decoder = new TextDecoder('utf-8');

--- a/content.js
+++ b/content.js
@@ -423,7 +423,7 @@ async function summarizeResults_own_key(results, searchQuery) {
     //console.log(response);
     if (!response.ok) {
         updateSummary(
-          'Either your credits are exhausted or you have entered the wrong OpenAPI token'
+          'Either your credits are exhausted or you have entered the wrong OpenAI token'
         );
         return;
       }


### PR DESCRIPTION
When OpenAI token is wrong or when the credits are exhausted, it still shows blurred loader.
<img width="473" alt="Screenshot 2024-05-23 at 12 12 36 AM" src="https://github.com/paraschopra/crossquery-extension/assets/4427269/76bf8a90-0497-4448-9ba2-07f4c1cbe6fe">


This MR will resolve this and show the proper message.
<img width="466" alt="Screenshot 2024-05-23 at 12 15 24 AM" src="https://github.com/paraschopra/crossquery-extension/assets/4427269/ed9dfd35-aec7-456e-aebb-dc98d2296e5a">

This will happen only when the openAIToken value is not falsy.
