### PR TITLE
Move away from class-based selectors to organic search result structure

### DIFF
--- a/content.js
+++ b/content.js
@@ -375,8 +375,7 @@ function updateSummary(summary) {
 function parseSearchResults(html) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
-
-    const searchResults = doc.querySelectorAll('.g');
+    const searchResults = doc.querySelector("#rso").childNodes
     const results = Array.from(searchResults).map(result => {
         const titleElement = result.querySelector('h3');
         const linkElement = result.querySelector('a');


### PR DESCRIPTION
## What’s Changed
Replaced dependency on class-based selectors with a more reliable structure using #rso and its children.
Used children instead of childNodes to filter out text nodes.

## Why This Change?
Google frequently updates its class names, causing breakages. By relying on the organic structure of search results, we ensure better stability and maintainability.